### PR TITLE
fix issue when using getMM

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -242,7 +242,8 @@ getMME <- function(object, vc=NULL, recordsToUse=NULL){
     rowsi <- list()
     for(j in 1:length(tn)){ # j=1
       ind <- (object@Gp)[tn[j]:(tn[j]+1L)]
-      rowsi[[j]] <- ((ind[1]+1L):ind[2])+1
+      # rowsi[[j]] <- ((ind[1]+1L):ind[2])+1 # Error
+      rowsi[[j]] <- ((ind[1] + 1L):ind[2]) + ncol(X)
     }
     Gi[unlist(rowsi),unlist(rowsi)] <- kronecker( LLt , solve( Matrix::nearPD( vcov )$mat ) )
     ##


### PR DESCRIPTION
In the function getMM:

It is build
C11 = X'R^{-1}X (fixed)
C22 = Z'R^{-1}Z (random)

So the penalty G^{-1} must be added only to the random block, i.e. inside the rows/cols corresponding to Z (offset by ncol(X)).

But the code does:

rowsi[[j]] <- ((ind[1] + 1L):ind[2]) + 1

That + 1 has no relationship to ncol(X).

To fix: use + ncol(X) (the same offset it is used later in the ROT section).